### PR TITLE
Pin Pulumi version in SDK project

### DIFF
--- a/sdk/dotnet/Pulumi.Bitlaunch.csproj
+++ b/sdk/dotnet/Pulumi.Bitlaunch.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.*" />
+    <PackageReference Include="Pulumi" Version="3.55.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pin Pulumi version in SDK project to 3.55.1 so that projects that depend on it can use the same version.