### PR TITLE
Pin Pulumi version in SDK examples

### DIFF
--- a/examples/test-example/dotnet-fsharp/dotnet-fsharp.fsproj
+++ b/examples/test-example/dotnet-fsharp/dotnet-fsharp.fsproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.*" />
+    <PackageReference Include="Pulumi" Version="3.55.1" />
     <PackageReference Include="Pulumi.FSharp" Version="3.55.1" />
     <ProjectReference Include="../../../sdk/dotnet/Pulumi.Bitlaunch.csproj" />
   </ItemGroup>

--- a/examples/test-example/dotnet/dotnet.csproj
+++ b/examples/test-example/dotnet/dotnet.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi" Version="3.*" />
+    <PackageReference Include="Pulumi" Version="3.55.1" />
     <ProjectReference Include="../../../sdk/dotnet/Pulumi.Bitlaunch.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Pin Pulumi version in SDK example projects to 3.55.1 so that projects that depend on it can use the same version.