### PR TITLE
Pin Pulumi version in provider

### DIFF
--- a/provider/cmd/pulumi-resource-bitlaunch/schema.json
+++ b/provider/cmd/pulumi-resource-bitlaunch/schema.json
@@ -17,7 +17,7 @@
     "language": {
         "csharp": {
             "packageReferences": {
-                "Pulumi": "3.*"
+                "Pulumi": "3.55.1"
             },
             "compatibility": "tfbridge20"
         },

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -174,7 +174,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		CSharp: &tfbridge.CSharpInfo{
 			PackageReferences: map[string]string{
-				"Pulumi": "3.*",
+				"Pulumi": "3.55.1",
 			},
 		},
 	}


### PR DESCRIPTION
Pin Pulumi version in provider so that generated .NET SDK project will use this version (3.55.1).